### PR TITLE
fixing mongo:3.6 ip bind error, installing ping on mongo image and fi…

### DIFF
--- a/kubernetes_config/tapira/tapira_pod.yaml
+++ b/kubernetes_config/tapira/tapira_pod.yaml
@@ -22,7 +22,7 @@ spec:
           ports:
             - containerPort: 5000
           env:
-            - name: db_root_password
+            - name: mongodb_password
               valueFrom:
                 secretKeyRef:
                   name: tapira-secrets

--- a/kubernetes_config/tapira_db/mongodb_config.yaml
+++ b/kubernetes_config/tapira_db/mongodb_config.yaml
@@ -9,6 +9,9 @@ data:
   init.sh: |
     #!/bin/bash
 
+    # Install ping
+    apt-get update && apt-get -y install iputils-ping
+
     # Need to wait for the readiness health check to pass so that the
     # mongo names resolve. This is kind of wonky.
     until ping -c 1 ${HOSTNAME}.mongo; do

--- a/kubernetes_config/tapira_db/mongodb_pod.yaml
+++ b/kubernetes_config/tapira_db/mongodb_pod.yaml
@@ -31,6 +31,7 @@ spec:
             - mongod
             - --replSet
             - rs0
+            - --bind_ip_all
           ports: 
             - containerPort: 27017
               name: peer


### PR DESCRIPTION
the pod cration mongodb-deployment
2.mongodb-client to test internal comunications 
3.A service to work as node port to provide outside access to the service, it works for internal comunications aswell

2 pods one for persitant volume and a secondary for a persitant volume claim , I commented on the one that i suggest NOT to use
mongodb-secrets.yaml to pass username and password
To test that username and pw worked I entered the container :

kubectl exec -it "nameofthepod"  /bin/bash -n apiclarity

I manage to test username and password from the mongo it self with mongo --host 127.0.0.1--port 32000 -u adminuser -p password123

It worked, 

So now  for internal comunications  from 
https://docs.mongodb.com/kubernetes-operator/master/tutorial/connect-from-outside-k8s/ and 
https://docs.mongodb.com/kubernetes-operator/master/tutorial/connect-from-inside-k8s/

*Pending tasks to test  connection syntax  from official docs****

* To connect to a sharded cluster resource named shardedcluster, you might use the following connection string:
mongo --host shardedcluster-mongos-0.shardedcluster-svc.mongodb.svc.cluster.local --port 27017

*When connecting to a resource from inside of Kubernetes, the hostname to which you connect has the following form:

<k8s-pod-name>.<k8s-internal-service-name>.<k8s-namespace>.<cluster-name>

Also if we are using a replica set, "kubectl expose pod " is needed to expose the pods . 

** Also another pending task   is to connect from the client pod , but when running from client pod the hostname should have the correct structure for the hostname *** 

mongo --host "correct mongodb host structure" --port 32000 -u adminuser -p password123

Final note :  the correct mongo hostdb structure should be use to connect in Tapira 