### PR TITLE
Save conflicts in the database and expose 2 endpoints:

### DIFF
--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -101,16 +101,16 @@
         "parameters": [
           {
             "in": "query",
-            "name": "service",
-            "required": true,
+            "name": "version",
+            "required": false,
             "schema": {
               "type": "string"
             }
           },
           {
             "in": "query",
-            "name": "version",
-            "required": false,
+            "name": "service",
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -311,6 +311,30 @@
       }
     },
     "/api/conflicts": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Services"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Returns list of services with conflicts",
+        "description": "Returns list of services with conflicts. If none provided specs compare with empty.",
+        "tags": [
+          "proposals_api"
+        ]
+      }
+    },
+    "/api/conflict": {
       "get": {
         "parameters": [
           {
@@ -331,7 +355,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ConflictsReponse"
+                  "$ref": "#/components/schemas/AllChangesComparison"
                 }
               }
             }
@@ -399,6 +423,14 @@
         "parameters": [
           {
             "in": "query",
+            "name": "new_version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "service",
             "required": true,
             "schema": {
@@ -408,14 +440,6 @@
           {
             "in": "query",
             "name": "old_version",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "new_version",
             "required": true,
             "schema": {
               "type": "string"
@@ -597,9 +621,9 @@
       "Error": {
         "type": "object",
         "properties": {
-          "message": {
-            "type": "string",
-            "description": "Error message"
+          "code": {
+            "type": "integer",
+            "description": "Error code"
           },
           "status": {
             "type": "string",
@@ -609,9 +633,9 @@
             "type": "object",
             "description": "Errors"
           },
-          "code": {
-            "type": "integer",
-            "description": "Error code"
+          "message": {
+            "type": "string",
+            "description": "Error message"
           }
         }
       },
@@ -677,13 +701,13 @@
       "ApiSpecEntry": {
         "type": "object",
         "properties": {
+          "name": {
+            "type": "string"
+          },
           "api_spec": {
             "type": "object"
           },
           "version": {
-            "type": "string"
-          },
-          "name": {
             "type": "string"
           },
           "created_at_date": {
@@ -738,16 +762,58 @@
           }
         }
       },
-      "NewEndpoint": {
+      "MissingEndpoint": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "type": "string",
+            "default": null,
+            "nullable": true
+          },
+          "method": {
+            "type": "string",
+            "nullable": true
+          },
+          "path_is_still_present": {
+            "type": "boolean"
+          },
+          "path_url": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ChangedOperation": {
         "type": "object",
         "properties": {
           "method": {
             "type": "string",
             "nullable": true
           },
+          "path_url": {
+            "type": "string",
+            "nullable": true
+          },
+          "changed_fields": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string",
+              "nullable": true
+            }
+          }
+        }
+      },
+      "NewEndpoint": {
+        "type": "object",
+        "properties": {
           "summary": {
             "type": "string",
             "default": null,
+            "nullable": true
+          },
+          "method": {
+            "type": "string",
             "nullable": true
           },
           "path_url": {
@@ -759,57 +825,19 @@
           }
         }
       },
-      "ChangedOperation": {
-        "type": "object",
-        "properties": {
-          "method": {
-            "type": "string",
-            "nullable": true
-          },
-          "changed_fields": {
-            "type": "array",
-            "nullable": true,
-            "items": {
-              "type": "string",
-              "nullable": true
-            }
-          },
-          "path_url": {
-            "type": "string",
-            "nullable": true
-          }
-        }
-      },
-      "MissingEndpoint": {
-        "type": "object",
-        "properties": {
-          "method": {
-            "type": "string",
-            "nullable": true
-          },
-          "path_is_still_present": {
-            "type": "boolean"
-          },
-          "summary": {
-            "type": "string",
-            "default": null,
-            "nullable": true
-          },
-          "path_url": {
-            "type": "string",
-            "nullable": true
-          }
-        }
-      },
       "ApiDiffsResponse": {
         "type": "object",
         "properties": {
-          "new_endpoints": {
+          "missing_endpoints": {
             "type": "array",
             "nullable": true,
             "items": {
-              "$ref": "#/components/schemas/NewEndpoint"
+              "$ref": "#/components/schemas/MissingEndpoint"
             }
+          },
+          "potentially_privacy_related_differences_given": {
+            "type": "boolean",
+            "nullable": true
           },
           "changed_operations": {
             "type": "array",
@@ -818,48 +846,31 @@
               "$ref": "#/components/schemas/ChangedOperation"
             }
           },
-          "missing_endpoints": {
+          "new_endpoints": {
             "type": "array",
             "nullable": true,
             "items": {
-              "$ref": "#/components/schemas/MissingEndpoint"
+              "$ref": "#/components/schemas/NewEndpoint"
             }
           },
           "general_difference_given": {
             "type": "boolean",
             "nullable": true
-          },
-          "potentially_privacy_related_differences_given": {
-            "type": "boolean",
-            "nullable": true
           }
         }
       },
-      "ConflictsReponse": {
+      "ChangedGlobalTiraAnnotation": {
         "type": "object",
         "properties": {
-          "api_diffs": {
-            "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ApiDiffsResponse"
-              }
-            ]
-          }
-        }
-      },
-      "ChangedSchemaTiraAnnotation": {
-        "type": "object",
-        "properties": {
-          "schema_name": {
+          "key": {
             "type": "string",
             "nullable": true
           },
-          "new_schema_tira_annotation": {
+          "new_global_tira_annotation": {
             "type": "object",
             "nullable": true
           },
-          "old_schema_tira_annotation": {
+          "old_global_tira_annotation": {
             "type": "object",
             "nullable": true
           }
@@ -878,19 +889,19 @@
           }
         }
       },
-      "ChangedGlobalTiraAnnotation": {
+      "ChangedSchemaTiraAnnotation": {
         "type": "object",
         "properties": {
-          "new_global_tira_annotation": {
+          "new_schema_tira_annotation": {
             "type": "object",
             "nullable": true
           },
-          "key": {
+          "old_schema_tira_annotation": {
+            "type": "object",
+            "nullable": true
+          },
+          "schema_name": {
             "type": "string",
-            "nullable": true
-          },
-          "old_global_tira_annotation": {
-            "type": "object",
             "nullable": true
           }
         }
@@ -898,18 +909,18 @@
       "ApiDiffTira": {
         "type": "object",
         "properties": {
-          "changed_schema_tira_annotations": {
+          "new_global_tira_annotation": {
             "type": "array",
             "nullable": true,
             "items": {
-              "$ref": "#/components/schemas/ChangedSchemaTiraAnnotation"
+              "type": "object"
             }
           },
-          "missing_schema_tira_annotations": {
+          "missing_global_tira_annotation": {
             "type": "array",
             "nullable": true,
             "items": {
-              "$ref": "#/components/schemas/SchemaTiraAnnotation"
+              "type": "object"
             }
           },
           "changed_global_tira_annotation": {
@@ -924,25 +935,25 @@
               ]
             }
           },
-          "new_schema_tira_annotations": {
+          "missing_schema_tira_annotations": {
             "type": "array",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/SchemaTiraAnnotation"
             }
           },
-          "missing_global_tira_annotation": {
+          "changed_schema_tira_annotations": {
             "type": "array",
             "nullable": true,
             "items": {
-              "type": "object"
+              "$ref": "#/components/schemas/ChangedSchemaTiraAnnotation"
             }
           },
-          "new_global_tira_annotation": {
+          "new_schema_tira_annotations": {
             "type": "array",
             "nullable": true,
             "items": {
-              "type": "object"
+              "$ref": "#/components/schemas/SchemaTiraAnnotation"
             }
           }
         }
@@ -950,9 +961,6 @@
       "AllChangesComparison": {
         "type": "object",
         "properties": {
-          "service": {
-            "type": "string"
-          },
           "api_diffs": {
             "nullable": true,
             "allOf": [
@@ -968,6 +976,9 @@
                 "$ref": "#/components/schemas/ApiDiffTira"
               }
             ]
+          },
+          "service": {
+            "type": "string"
           }
         },
         "required": [

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -423,6 +423,14 @@
         "parameters": [
           {
             "in": "query",
+            "name": "old_version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "new_version",
             "required": true,
             "schema": {
@@ -432,14 +440,6 @@
           {
             "in": "query",
             "name": "service",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "old_version",
             "required": true,
             "schema": {
               "type": "string"
@@ -472,7 +472,7 @@
       }
     },
     "/api/proposed_merge": {
-      "get": {
+      "post": {
         "parameters": [
           {
             "in": "query",
@@ -621,9 +621,9 @@
       "Error": {
         "type": "object",
         "properties": {
-          "code": {
-            "type": "integer",
-            "description": "Error code"
+          "message": {
+            "type": "string",
+            "description": "Error message"
           },
           "status": {
             "type": "string",
@@ -633,9 +633,9 @@
             "type": "object",
             "description": "Errors"
           },
-          "message": {
-            "type": "string",
-            "description": "Error message"
+          "code": {
+            "type": "integer",
+            "description": "Error code"
           }
         }
       },
@@ -701,16 +701,16 @@
       "ApiSpecEntry": {
         "type": "object",
         "properties": {
-          "name": {
+          "version": {
+            "type": "string"
+          },
+          "created_at_date": {
             "type": "string"
           },
           "api_spec": {
             "type": "object"
           },
-          "version": {
-            "type": "string"
-          },
-          "created_at_date": {
+          "name": {
             "type": "string"
           }
         },
@@ -762,14 +762,30 @@
           }
         }
       },
-      "MissingEndpoint": {
+      "NewEndpoint": {
         "type": "object",
         "properties": {
+          "method": {
+            "type": "string",
+            "nullable": true
+          },
+          "path_is_new": {
+            "type": "boolean"
+          },
+          "path_url": {
+            "type": "string",
+            "nullable": true
+          },
           "summary": {
             "type": "string",
             "default": null,
             "nullable": true
-          },
+          }
+        }
+      },
+      "MissingEndpoint": {
+        "type": "object",
+        "properties": {
           "method": {
             "type": "string",
             "nullable": true
@@ -779,6 +795,11 @@
           },
           "path_url": {
             "type": "string",
+            "nullable": true
+          },
+          "summary": {
+            "type": "string",
+            "default": null,
             "nullable": true
           }
         }
@@ -790,10 +811,6 @@
             "type": "string",
             "nullable": true
           },
-          "path_url": {
-            "type": "string",
-            "nullable": true
-          },
           "changed_fields": {
             "type": "array",
             "nullable": true,
@@ -801,51 +818,16 @@
               "type": "string",
               "nullable": true
             }
-          }
-        }
-      },
-      "NewEndpoint": {
-        "type": "object",
-        "properties": {
-          "summary": {
-            "type": "string",
-            "default": null,
-            "nullable": true
-          },
-          "method": {
-            "type": "string",
-            "nullable": true
           },
           "path_url": {
             "type": "string",
             "nullable": true
-          },
-          "path_is_new": {
-            "type": "boolean"
           }
         }
       },
       "ApiDiffsResponse": {
         "type": "object",
         "properties": {
-          "missing_endpoints": {
-            "type": "array",
-            "nullable": true,
-            "items": {
-              "$ref": "#/components/schemas/MissingEndpoint"
-            }
-          },
-          "potentially_privacy_related_differences_given": {
-            "type": "boolean",
-            "nullable": true
-          },
-          "changed_operations": {
-            "type": "array",
-            "nullable": true,
-            "items": {
-              "$ref": "#/components/schemas/ChangedOperation"
-            }
-          },
           "new_endpoints": {
             "type": "array",
             "nullable": true,
@@ -856,22 +838,23 @@
           "general_difference_given": {
             "type": "boolean",
             "nullable": true
-          }
-        }
-      },
-      "ChangedGlobalTiraAnnotation": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string",
-            "nullable": true
           },
-          "new_global_tira_annotation": {
-            "type": "object",
-            "nullable": true
+          "missing_endpoints": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/MissingEndpoint"
+            }
           },
-          "old_global_tira_annotation": {
-            "type": "object",
+          "changed_operations": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/ChangedOperation"
+            }
+          },
+          "potentially_privacy_related_differences_given": {
+            "type": "boolean",
             "nullable": true
           }
         }
@@ -879,12 +862,12 @@
       "SchemaTiraAnnotation": {
         "type": "object",
         "properties": {
-          "schema_name": {
-            "type": "string",
-            "nullable": true
-          },
           "schema_tira_annotation": {
             "type": "object",
+            "nullable": true
+          },
+          "schema_name": {
+            "type": "string",
             "nullable": true
           }
         }
@@ -892,15 +875,32 @@
       "ChangedSchemaTiraAnnotation": {
         "type": "object",
         "properties": {
-          "new_schema_tira_annotation": {
-            "type": "object",
-            "nullable": true
-          },
           "old_schema_tira_annotation": {
             "type": "object",
             "nullable": true
           },
+          "new_schema_tira_annotation": {
+            "type": "object",
+            "nullable": true
+          },
           "schema_name": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "ChangedGlobalTiraAnnotation": {
+        "type": "object",
+        "properties": {
+          "new_global_tira_annotation": {
+            "type": "object",
+            "nullable": true
+          },
+          "old_global_tira_annotation": {
+            "type": "object",
+            "nullable": true
+          },
+          "key": {
             "type": "string",
             "nullable": true
           }
@@ -909,14 +909,35 @@
       "ApiDiffTira": {
         "type": "object",
         "properties": {
-          "new_global_tira_annotation": {
+          "missing_global_tira_annotation": {
             "type": "array",
             "nullable": true,
             "items": {
               "type": "object"
             }
           },
-          "missing_global_tira_annotation": {
+          "new_schema_tira_annotations": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/SchemaTiraAnnotation"
+            }
+          },
+          "changed_schema_tira_annotations": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/ChangedSchemaTiraAnnotation"
+            }
+          },
+          "missing_schema_tira_annotations": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/SchemaTiraAnnotation"
+            }
+          },
+          "new_global_tira_annotation": {
             "type": "array",
             "nullable": true,
             "items": {
@@ -933,27 +954,6 @@
                   "$ref": "#/components/schemas/ChangedGlobalTiraAnnotation"
                 }
               ]
-            }
-          },
-          "missing_schema_tira_annotations": {
-            "type": "array",
-            "nullable": true,
-            "items": {
-              "$ref": "#/components/schemas/SchemaTiraAnnotation"
-            }
-          },
-          "changed_schema_tira_annotations": {
-            "type": "array",
-            "nullable": true,
-            "items": {
-              "$ref": "#/components/schemas/ChangedSchemaTiraAnnotation"
-            }
-          },
-          "new_schema_tira_annotations": {
-            "type": "array",
-            "nullable": true,
-            "items": {
-              "$ref": "#/components/schemas/SchemaTiraAnnotation"
             }
           }
         }

--- a/api-spec/openapi.yaml
+++ b/api-spec/openapi.yaml
@@ -66,13 +66,13 @@ paths:
     get:
       parameters:
         - in: query
-          name: service
-          required: true
+          name: version
+          required: false
           schema:
             type: string
         - in: query
-          name: version
-          required: false
+          name: service
+          required: true
           schema:
             type: string
       responses:
@@ -198,6 +198,22 @@ paths:
       tags:
         - proposals_api
   "/api/conflicts":
+    post:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Services"
+        default:
+          "$ref": "#/components/responses/DEFAULT_ERROR"
+      summary: Returns list of services with conflicts
+      description: Returns list of services with conflicts. If none provided specs
+        compare with empty.
+      tags:
+        - proposals_api
+  "/api/conflict":
     get:
       parameters:
         - in: query
@@ -211,7 +227,7 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/ConflictsReponse"
+                "$ref": "#/components/schemas/AllChangesComparison"
         '422':
           "$ref": "#/components/responses/UNPROCESSABLE_ENTITY"
         default:
@@ -255,17 +271,17 @@ paths:
     get:
       parameters:
         - in: query
+          name: new_version
+          required: true
+          schema:
+            type: string
+        - in: query
           name: service
           required: true
           schema:
             type: string
         - in: query
           name: old_version
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: new_version
           required: true
           schema:
             type: string
@@ -380,18 +396,18 @@ components:
     Error:
       type: object
       properties:
-        message:
-          type: string
-          description: Error message
+        code:
+          type: integer
+          description: Error code
         status:
           type: string
           description: Error name
         errors:
           type: object
           description: Errors
-        code:
-          type: integer
-          description: Error code
+        message:
+          type: string
+          description: Error message
     PaginationMetadata:
       type: object
       properties:
@@ -433,11 +449,11 @@ components:
     ApiSpecEntry:
       type: object
       properties:
+        name:
+          type: string
         api_spec:
           type: object
         version:
-          type: string
-        name:
           type: string
         created_at_date:
           type: string
@@ -471,25 +487,28 @@ components:
       properties:
         number_of_deleted:
           type: string
-    NewEndpoint:
+    MissingEndpoint:
       type: object
       properties:
-        method:
-          type: string
-          nullable: true
         summary:
           type: string
           default:
           nullable: true
+        method:
+          type: string
+          nullable: true
+        path_is_still_present:
+          type: boolean
         path_url:
           type: string
           nullable: true
-        path_is_new:
-          type: boolean
     ChangedOperation:
       type: object
       properties:
         method:
+          type: string
+          nullable: true
+        path_url:
           type: string
           nullable: true
         changed_fields:
@@ -498,65 +517,55 @@ components:
           items:
             type: string
             nullable: true
-        path_url:
-          type: string
-          nullable: true
-    MissingEndpoint:
+    NewEndpoint:
       type: object
       properties:
-        method:
-          type: string
-          nullable: true
-        path_is_still_present:
-          type: boolean
         summary:
           type: string
           default:
           nullable: true
+        method:
+          type: string
+          nullable: true
         path_url:
           type: string
           nullable: true
+        path_is_new:
+          type: boolean
     ApiDiffsResponse:
       type: object
       properties:
-        new_endpoints:
-          type: array
-          nullable: true
-          items:
-            "$ref": "#/components/schemas/NewEndpoint"
-        changed_operations:
-          type: array
-          nullable: true
-          items:
-            "$ref": "#/components/schemas/ChangedOperation"
         missing_endpoints:
           type: array
           nullable: true
           items:
             "$ref": "#/components/schemas/MissingEndpoint"
-        general_difference_given:
-          type: boolean
-          nullable: true
         potentially_privacy_related_differences_given:
           type: boolean
           nullable: true
-    ConflictsReponse:
-      type: object
-      properties:
-        api_diffs:
+        changed_operations:
+          type: array
           nullable: true
-          allOf:
-            - "$ref": "#/components/schemas/ApiDiffsResponse"
-    ChangedSchemaTiraAnnotation:
+          items:
+            "$ref": "#/components/schemas/ChangedOperation"
+        new_endpoints:
+          type: array
+          nullable: true
+          items:
+            "$ref": "#/components/schemas/NewEndpoint"
+        general_difference_given:
+          type: boolean
+          nullable: true
+    ChangedGlobalTiraAnnotation:
       type: object
       properties:
-        schema_name:
+        key:
           type: string
           nullable: true
-        new_schema_tira_annotation:
+        new_global_tira_annotation:
           type: object
           nullable: true
-        old_schema_tira_annotation:
+        old_global_tira_annotation:
           type: object
           nullable: true
     SchemaTiraAnnotation:
@@ -568,31 +577,31 @@ components:
         schema_tira_annotation:
           type: object
           nullable: true
-    ChangedGlobalTiraAnnotation:
+    ChangedSchemaTiraAnnotation:
       type: object
       properties:
-        new_global_tira_annotation:
+        new_schema_tira_annotation:
           type: object
           nullable: true
-        key:
+        old_schema_tira_annotation:
+          type: object
+          nullable: true
+        schema_name:
           type: string
-          nullable: true
-        old_global_tira_annotation:
-          type: object
           nullable: true
     ApiDiffTira:
       type: object
       properties:
-        changed_schema_tira_annotations:
+        new_global_tira_annotation:
           type: array
           nullable: true
           items:
-            "$ref": "#/components/schemas/ChangedSchemaTiraAnnotation"
-        missing_schema_tira_annotations:
+            type: object
+        missing_global_tira_annotation:
           type: array
           nullable: true
           items:
-            "$ref": "#/components/schemas/SchemaTiraAnnotation"
+            type: object
         changed_global_tira_annotation:
           type: array
           nullable: true
@@ -600,26 +609,24 @@ components:
             nullable: true
             allOf:
               - "$ref": "#/components/schemas/ChangedGlobalTiraAnnotation"
+        missing_schema_tira_annotations:
+          type: array
+          nullable: true
+          items:
+            "$ref": "#/components/schemas/SchemaTiraAnnotation"
+        changed_schema_tira_annotations:
+          type: array
+          nullable: true
+          items:
+            "$ref": "#/components/schemas/ChangedSchemaTiraAnnotation"
         new_schema_tira_annotations:
           type: array
           nullable: true
           items:
             "$ref": "#/components/schemas/SchemaTiraAnnotation"
-        missing_global_tira_annotation:
-          type: array
-          nullable: true
-          items:
-            type: object
-        new_global_tira_annotation:
-          type: array
-          nullable: true
-          items:
-            type: object
     AllChangesComparison:
       type: object
       properties:
-        service:
-          type: string
         api_diffs:
           nullable: true
           allOf:
@@ -628,6 +635,8 @@ components:
           nullable: true
           allOf:
             - "$ref": "#/components/schemas/ApiDiffTira"
+        service:
+          type: string
       required:
         - service
     ProposedMergeRequestBody:

--- a/api-spec/openapi.yaml
+++ b/api-spec/openapi.yaml
@@ -271,17 +271,17 @@ paths:
     get:
       parameters:
         - in: query
+          name: old_version
+          required: true
+          schema:
+            type: string
+        - in: query
           name: new_version
           required: true
           schema:
             type: string
         - in: query
           name: service
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: old_version
           required: true
           schema:
             type: string
@@ -303,7 +303,7 @@ paths:
       tags:
         - comparison_api
   "/api/proposed_merge":
-    get:
+    post:
       parameters:
         - in: query
           name: context
@@ -396,18 +396,18 @@ components:
     Error:
       type: object
       properties:
-        code:
-          type: integer
-          description: Error code
+        message:
+          type: string
+          description: Error message
         status:
           type: string
           description: Error name
         errors:
           type: object
           description: Errors
-        message:
-          type: string
-          description: Error message
+        code:
+          type: integer
+          description: Error code
     PaginationMetadata:
       type: object
       properties:
@@ -449,13 +449,13 @@ components:
     ApiSpecEntry:
       type: object
       properties:
-        name:
-          type: string
-        api_spec:
-          type: object
         version:
           type: string
         created_at_date:
+          type: string
+        api_spec:
+          type: object
+        name:
           type: string
       required:
         - name
@@ -487,13 +487,24 @@ components:
       properties:
         number_of_deleted:
           type: string
-    MissingEndpoint:
+    NewEndpoint:
       type: object
       properties:
+        method:
+          type: string
+          nullable: true
+        path_is_new:
+          type: boolean
+        path_url:
+          type: string
+          nullable: true
         summary:
           type: string
           default:
           nullable: true
+    MissingEndpoint:
+      type: object
+      properties:
         method:
           type: string
           nullable: true
@@ -502,13 +513,14 @@ components:
         path_url:
           type: string
           nullable: true
+        summary:
+          type: string
+          default:
+          nullable: true
     ChangedOperation:
       type: object
       properties:
         method:
-          type: string
-          nullable: true
-        path_url:
           type: string
           nullable: true
         changed_fields:
@@ -517,37 +529,12 @@ components:
           items:
             type: string
             nullable: true
-    NewEndpoint:
-      type: object
-      properties:
-        summary:
-          type: string
-          default:
-          nullable: true
-        method:
-          type: string
-          nullable: true
         path_url:
           type: string
           nullable: true
-        path_is_new:
-          type: boolean
     ApiDiffsResponse:
       type: object
       properties:
-        missing_endpoints:
-          type: array
-          nullable: true
-          items:
-            "$ref": "#/components/schemas/MissingEndpoint"
-        potentially_privacy_related_differences_given:
-          type: boolean
-          nullable: true
-        changed_operations:
-          type: array
-          nullable: true
-          items:
-            "$ref": "#/components/schemas/ChangedOperation"
         new_endpoints:
           type: array
           nullable: true
@@ -556,48 +543,76 @@ components:
         general_difference_given:
           type: boolean
           nullable: true
+        missing_endpoints:
+          type: array
+          nullable: true
+          items:
+            "$ref": "#/components/schemas/MissingEndpoint"
+        changed_operations:
+          type: array
+          nullable: true
+          items:
+            "$ref": "#/components/schemas/ChangedOperation"
+        potentially_privacy_related_differences_given:
+          type: boolean
+          nullable: true
+    SchemaTiraAnnotation:
+      type: object
+      properties:
+        schema_tira_annotation:
+          type: object
+          nullable: true
+        schema_name:
+          type: string
+          nullable: true
+    ChangedSchemaTiraAnnotation:
+      type: object
+      properties:
+        old_schema_tira_annotation:
+          type: object
+          nullable: true
+        new_schema_tira_annotation:
+          type: object
+          nullable: true
+        schema_name:
+          type: string
+          nullable: true
     ChangedGlobalTiraAnnotation:
       type: object
       properties:
-        key:
-          type: string
-          nullable: true
         new_global_tira_annotation:
           type: object
           nullable: true
         old_global_tira_annotation:
           type: object
           nullable: true
-    SchemaTiraAnnotation:
-      type: object
-      properties:
-        schema_name:
-          type: string
-          nullable: true
-        schema_tira_annotation:
-          type: object
-          nullable: true
-    ChangedSchemaTiraAnnotation:
-      type: object
-      properties:
-        new_schema_tira_annotation:
-          type: object
-          nullable: true
-        old_schema_tira_annotation:
-          type: object
-          nullable: true
-        schema_name:
+        key:
           type: string
           nullable: true
     ApiDiffTira:
       type: object
       properties:
-        new_global_tira_annotation:
+        missing_global_tira_annotation:
           type: array
           nullable: true
           items:
             type: object
-        missing_global_tira_annotation:
+        new_schema_tira_annotations:
+          type: array
+          nullable: true
+          items:
+            "$ref": "#/components/schemas/SchemaTiraAnnotation"
+        changed_schema_tira_annotations:
+          type: array
+          nullable: true
+          items:
+            "$ref": "#/components/schemas/ChangedSchemaTiraAnnotation"
+        missing_schema_tira_annotations:
+          type: array
+          nullable: true
+          items:
+            "$ref": "#/components/schemas/SchemaTiraAnnotation"
+        new_global_tira_annotation:
           type: array
           nullable: true
           items:
@@ -609,21 +624,6 @@ components:
             nullable: true
             allOf:
               - "$ref": "#/components/schemas/ChangedGlobalTiraAnnotation"
-        missing_schema_tira_annotations:
-          type: array
-          nullable: true
-          items:
-            "$ref": "#/components/schemas/SchemaTiraAnnotation"
-        changed_schema_tira_annotations:
-          type: array
-          nullable: true
-          items:
-            "$ref": "#/components/schemas/ChangedSchemaTiraAnnotation"
-        new_schema_tira_annotations:
-          type: array
-          nullable: true
-          items:
-            "$ref": "#/components/schemas/SchemaTiraAnnotation"
     AllChangesComparison:
       type: object
       properties:

--- a/backend/api/merge_api.py
+++ b/backend/api/merge_api.py
@@ -19,7 +19,7 @@ class Test4(MethodView):
     @blp.arguments(schema.ProposedMergeParameterSchema, location="query")
     @blp.arguments(schema.ProposedMergeRequestBodySchema, location="json")
     @blp.response(200)
-    def get(self, args, request_body):
+    def post(self, args, request_body):
         """Get a proposed merge of both api specifications
 
         Get a proposed merge of both api specifications in the context of validation or comparison.

--- a/backend/repository/api_spec_proposals_repo.py
+++ b/backend/repository/api_spec_proposals_repo.py
@@ -48,21 +48,30 @@ def find_proposal_by_name(service):
     return get_db().api_spec_proposals.find_one({"service": service})
 
 
-# def insert_conflict(service_name, api_diffs: ApiDiffs, old_version, new_version):
-#     print(f'Inserting conflicts for service: {service_name} and versions {old_version}<->{new_version}')
-#
-#     return get_db().spec_conflicts.insert_one(
-#         {"service": service_name, "old_version": old_version, "new_version": new_version,
-#          "api_diffs": api_diffs.__dict__})
-#
-#
-# def delete_conflict_by_service_name_and_versions(service, old_version, new_version):
-#     deleted = get_db().spec_conflicts.delete_one(
-#         {"service": service, "old_version": old_version, "version2": new_version})
-#
-#     if deleted.deleted_count == 1:
-#         print(f'{service}: deleted conflict for versions: {old_version}<->{new_version}')
-#
-#
-# def delete_all_conflicts_by_service_name(service):
-#     deleted = get_db().spec_conflicts.delete_many({"service": service})
+def insert_conflict(service_name, api_diffs: ApiDiffs):
+    print(f'Inserting conflicts for service: {service_name}')
+
+    return get_db().spec_conflicts.insert_one(
+        {"service": service_name,
+         "api_diffs": api_diffs.__dict__})
+
+
+def find_conflict(service_name):
+    conflict = get_db().spec_conflicts.find_one({"service": service_name})
+    return None if conflict is None else conflict["api_diffs"]
+
+
+def delete_conflict_by_service_name_and_versions(service, old_version, new_version):
+    deleted = get_db().spec_conflicts.delete_one(
+        {"service": service, "old_version": old_version, "version2": new_version})
+
+    if deleted.deleted_count == 1:
+        print(f'{service}: deleted conflict for versions: {old_version}<->{new_version}')
+
+
+def delete_all_conflicts_by_service_name(service):
+    deleted = get_db().spec_conflicts.delete_many({"service": service})
+
+
+def delete_all_conflicts():
+    deleted = get_db().spec_conflicts.delete_many({})

--- a/backend/services/apidiff_service.py
+++ b/backend/services/apidiff_service.py
@@ -2,11 +2,11 @@ import json
 
 import humps
 import requests
+from flask_smorest import abort
 
 from backend import config
 from backend.schema.schema import ApiDiffsResponseSchema, ApiDiffTiraSchema
 from backend.services import collection_service
-from flask_smorest import abort
 
 
 def get_all_diffs_for_two_versions(service_name, old_version, new_version):
@@ -23,7 +23,9 @@ def get_all_diffs_for_two_versions(service_name, old_version, new_version):
 
     return {"service": service_name, "api_diffs": api_diffs, "tira_diffs": tira_diffs}
 
-def get_all_diffs_for_two_openapi_specs(service_name, old_spec, new_spec): #method for two OpenApi specs and not two ApiSpecEntry
+
+def get_all_diffs_for_two_openapi_specs(service_name, old_spec,
+                                        new_spec):  # method for two OpenApi specs and not two ApiSpecEntry
     if old_spec is None:
         abort(400, message=f'Old Spec missing for service:{service_name}')
     elif new_spec is None:
@@ -64,5 +66,3 @@ def get_tira_changes(first_spec, second_spec):
     return ApiDiffTiraSchema().loads(json.dumps(response_body_decamelized))
 
 
-def is_empty(list_changes: []):
-    return list_changes is None or len(list_changes) == 0

--- a/backend/services/collection_service.py
+++ b/backend/services/collection_service.py
@@ -95,6 +95,8 @@ def extract_api_specs(apiclarity_specs, update_new_reconstructed_services):
             continue
 
         proposal_repo.delete_by_name_and_return_timestamp_of_previous(service_name)
+        proposal_repo.delete_all_conflicts_by_service_name(service_name)
+
         reconstructed_spec = json.loads(get_reconstructed_spec(spec_wrapper))
         proposal_repo.insert_api_spec_proposal(service_name, reconstructed_spec)
 
@@ -132,6 +134,7 @@ def insert_provided_spec(uploaded_file, service_name):
     print(f"Inserting new api spec for service={service_name} and deleting existing proposal for it")
     spec_repo.insert_api_spec(service_name, new_spec_version, api_spec)
     proposal_repo.delete_by_name_and_return_timestamp_of_previous(service_name)
+    proposal_repo.delete_all_conflicts_by_service_name(service_name)
 
     return new_spec_version
 

--- a/backend/services/conflicts_service.py
+++ b/backend/services/conflicts_service.py
@@ -1,0 +1,40 @@
+from backend.models.models import ApiDiffs
+from backend.repository import api_spec_proposals_repo as proposal_repo
+from backend.services import collection_service, apidiff_service
+
+
+def get_all_reconstructed_and_create_conflicts():
+    service_name_proposals = collection_service.get_service_names_with_proposals()
+    proposal_repo.delete_all_conflicts()
+
+    services_with_conflicts = []
+    for i in range(len(service_name_proposals)):
+        proposal = collection_service.get_proposal(service_name_proposals[i])
+        current_version_spec_entry = collection_service.get_latest_spec(service_name_proposals[i])
+
+        is_conflict = get_api_diffs_and_create_conflict(service_name_proposals[i], current_version_spec_entry, proposal)
+
+        if is_conflict:
+            services_with_conflicts.append(service_name_proposals[i])
+
+    return services_with_conflicts
+
+
+def get_api_diffs_and_create_conflict(service_name, current_version_spec_entry, proposal):
+    current_version = {} if current_version_spec_entry is None else current_version_spec_entry.api_spec
+
+    diffs: ApiDiffs = apidiff_service.get_api_diffs(current_version, proposal)
+    if not is_empty(diffs.changed_operations) or not is_empty(
+            diffs.missing_endpoints) or not is_empty(diffs.new_endpoints):
+        proposal_repo.insert_conflict(service_name, diffs)
+        return True
+
+    return False
+
+
+def get_conflict(service_name):
+    return proposal_repo.find_conflict(service_name)
+
+
+def is_empty(list_changes: []):
+    return list_changes is None or len(list_changes) == 0


### PR DESCRIPTION
- POST /conflicts - deletes existing conflicts, creates new ones based on reconstructed specs and returns list of service names
- GET /conflict?service=<> - gets current conflict based on the service name